### PR TITLE
Revert tagname change for Github

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
         - run:
             name: Deploying to Github
             command: |
-                rid=$(curl -H "Content-Type: application/json" -H "Authorization: token $API_Token_Github" -X POST -d '{"tag_name":"Shippo Java Client '$version'", "target_commitish":"release","name":"'$version'","body":"", "draft":true, "prerelease":false}' https://api.github.com/repos/goshippo/shippo-java-client/releases | jq '.id')
+                rid=$(curl -H "Content-Type: application/json" -H "Authorization: token $API_Token_Github" -X POST -d '{"tag_name":"'$version'", "target_commitish":"release","name":"Shippo Java Client '$version'","body":"", "draft":true, "prerelease":false}' https://api.github.com/repos/goshippo/shippo-java-client/releases | jq '.id')
                 curl -H "Content-Type: application/octet-stream" -H "Authorization: token $API_Token_Github" -X POST --data-binary @target/shippo-java-client-$version-javadoc.jar https://uploads.github.com/repos/goshippo/shippo-java-client/releases/$rid/assets?name=shippo-java-client-$version-javadoc.jar
                 curl -H "Content-Type: application/octet-stream" -H "Authorization: token $API_Token_Github" -X POST --data-binary @target/shippo-java-client-$version-sources.jar https://uploads.github.com/repos/goshippo/shippo-java-client/releases/$rid/assets?name=shippo-java-client-$version-sources.jar
                 curl -H "Content-Type: application/octet-stream" -H "Authorization: token $API_Token_Github" -X POST --data-binary @target/shippo-java-client-$version.jar https://uploads.github.com/repos/goshippo/shippo-java-client/releases/$rid/assets?name=shippo-java-client-$version.jar

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.goshippo</groupId>
     <artifactId>shippo-java-client</artifactId>
-    <version>v2.1.3</version>
+    <version>v2.1.4</version>
     <packaging>jar</packaging>
     <name>Shippo Java Client</name>
     <description>Shippo Java Bindings</description>


### PR DESCRIPTION
Github push should hopefully work now.

Tested locally.