### PR TITLE
make address validation field public, move test to other package

### DIFF
--- a/src/main/java/com/shippo/model/Address.java
+++ b/src/main/java/com/shippo/model/Address.java
@@ -16,7 +16,7 @@ public class Address extends APIResource {
 	@SerializedName("is_complete")
 	boolean isComplete;
 
-	String objectId;
+	public String objectId;
 	String objectOwner;
 	Object objectCreated;
 	Object objectUpdated;
@@ -37,14 +37,14 @@ public class Address extends APIResource {
 	ValidationResults validation_results;
 
     public class ValidationResults {
-    	boolean is_valid;
-    	List<ValidationMessages> messages;
+    	public boolean is_valid;
+    	public List<ValidationMessages> messages;
 	}
 
 	public class ValidationMessages {
-		String source;
-		String code;
-		String text;
+		public String source;
+		public String code;
+		public String text;
 	}
 
     public static Address createForPurchase(String name, String street1, String city, String zip, String state,

--- a/src/test/java/com/shippo/model/ManifestTest.java
+++ b/src/test/java/com/shippo/model/ManifestTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
+import com.shippo.model.test.AddressTest;
 import org.junit.Test;
 
 import com.shippo.exception.APIConnectionException;

--- a/src/test/java/com/shippo/model/ShipmentTest.java
+++ b/src/test/java/com/shippo/model/ShipmentTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
+import com.shippo.model.test.AddressTest;
 import org.junit.Test;
 
 import com.shippo.exception.APIConnectionException;

--- a/src/test/java/com/shippo/model/test/AddressTest.java
+++ b/src/test/java/com/shippo/model/test/AddressTest.java
@@ -1,10 +1,13 @@
-package com.shippo.model;
+package com.shippo.model.test;
 
 import static org.junit.Assert.*;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import com.shippo.model.Address;
+import com.shippo.model.AddressCollection;
+import com.shippo.model.ShippoTest;
 import org.junit.Test;
 
 import com.shippo.exception.APIConnectionException;


### PR DESCRIPTION
I am not able to read `is_valid` and `messages` from `ValidationResults`. It is because this fields have default access modifier. I have updated them to public and also moved address test to other package to be sure it works at other package. 